### PR TITLE
Fix the broken markdown link.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,6 @@ func main() {
 
 # Disclaimer
 
-The durable channel is based on the disk queue of (nsqd)[https://github.com/nsqio/nsq/blob/master/nsqd/diskqueue.go].
+The durable channel is based on the disk queue of [nsqd](https://github.com/nsqio/nsq/blob/master/nsqd/diskqueue.go).
 
 


### PR DESCRIPTION
Just swap `[` & `(` around a little :)